### PR TITLE
Component linking

### DIFF
--- a/BlazorBook/Components/Component.razor
+++ b/BlazorBook/Components/Component.razor
@@ -1,5 +1,7 @@
 @page "/blazorbook/story/{id}"
 
+<PageTitle>@BlazorBook.Stories.MetadataByName(Id).Name</PageTitle>
+
 @renderWidget(BlazorBook.Stories.MetadataByName(Id))
 
 @code {

--- a/BlazorBook/Components/ComponentGroup.razor
+++ b/BlazorBook/Components/ComponentGroup.razor
@@ -5,7 +5,9 @@
 <ul>
     @foreach (var childGroup in Group.Children)
     {
-        <ComponentGroup Group="@childGroup" />
+        <li>
+            <ComponentGroup Group="@childGroup" />
+        </li>
     }
     @foreach (var component in Group.Components)
     {

--- a/BlazorBook/Components/ComponentGroup.razor
+++ b/BlazorBook/Components/ComponentGroup.razor
@@ -12,7 +12,11 @@
     @foreach (var component in Group.Components)
     {
         <li class="@classList(component.Slug)">
-            <button @onclick="@(() => SetCurrentStory(component.Slug))">@component.Name</button>
+
+            <a href="/blazorbook/story/@component.Slug"
+                @onclick="@(() => SetCurrentStory(component.Slug))"
+                target="frame"
+                >@component.Name</a>
         </li>
     }
     </ul>

--- a/BlazorBook/Components/MainPane.razor
+++ b/BlazorBook/Components/MainPane.razor
@@ -1,7 +1,7 @@
 ﻿ <Fill>
     <Fill class="main-pane">
         <Fill>
-            <iframe src="@iframeSource" frameBorder="0" style="width: 100%; height: 100%;" />
+            <iframe src="@iframeSource" frameBorder="0" style="width: 100%; height: 100%;" name="frame" />
         </Fill>
     </Fill>
 </Fill>

--- a/BlazorBook/wwwroot/styles.css
+++ b/BlazorBook/wwwroot/styles.css
@@ -1,9 +1,9 @@
-.storybook {
+﻿.storybook {
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 14.4px;
   background: #f6f9fc;
   -webkit-font-smoothing: antialiased;
-  -webkit-tap-highlight-color: transparent;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   -moz-osx-font-smoothing: grayscale;
 }
 .storybook .main-pane {
@@ -95,6 +95,7 @@
 .storybook .sidebar .component-list ul li {
   padding: 4px 0.5rem 0 0.5rem;
 }
+.storybook .sidebar .component-list ul li a,
 .storybook .sidebar .component-list ul li button {
   text-align: left;
   display: block;
@@ -110,10 +111,12 @@
   border: none;
   margin: 0;
 }
+.storybook .sidebar .component-list ul li a:hover,
 .storybook .sidebar .component-list ul li button:hover {
   color: white;
   background-color: rgba(255, 255, 255, 0.1);
 }
+.storybook .sidebar .component-list ul li.active a,
 .storybook .sidebar .component-list ul li.active button {
   background-color: rgba(255, 255, 255, 0.1);
   color: white;

--- a/BlazorBook/wwwroot/styles.less
+++ b/BlazorBook/wwwroot/styles.less
@@ -108,6 +108,7 @@
                 li {
                     padding: 4px 0.5rem 0 0.5rem;
 
+                    a,
                     button {
                         text-align: left;
                         display: block;
@@ -130,6 +131,7 @@
                     }
 
                     &.active {
+                        a,
                         button {
                             background-color: rgba(255,255,255,0.1);
                             color: white;


### PR DESCRIPTION
G’day, 

I’ve been using blazor-book to document our components and I’ve found it useful to link to the individual component stories. 

The changes made in this PR aim to improve the experience of using blazor-book in that way:

- Page titles on individual component pages make the name of the component readily available when bookmarking or in browser tabs.
- Sidebar links to component pages make it easier to get the url for a specific component (e.g. via browser contextual menu)

While I was at it I fixed the HTML resulted when components are grouped.

Thank-you for this useful project!